### PR TITLE
Update of the Flatpak Texlive SDK Extension

### DIFF
--- a/net.xm1math.Texmaker.yaml
+++ b/net.xm1math.Texmaker.yaml
@@ -25,7 +25,7 @@ cleanup-commands:
 
 add-extensions:
   org.freedesktop.Sdk.Extension.texlive:
-    version: '20.08'
+    version: '22.08'
     directory: texlive # this is relative to /app
 
 modules:


### PR DESCRIPTION
Update of the Flatpak Texlive SDK Extension to branch 22.08 - Branch 22.08 contains important additions such as biber/biblatex support absent from the 20.08 branch along with bugfixes and regular updates to various packages