### PR TITLE
Set INSTALL_DIR to /app

### DIFF
--- a/CMakeLists.txt.patch
+++ b/CMakeLists.txt.patch
@@ -1,5 +1,5 @@
 --- a/CMakeLists.txt	2026-01-17 16:23:42.056121262 -0500
-+++ b/CMakeLists.txt	2026-05-19 14:17:07.001803545 +0200
++++ b/CMakeLists.txt	2026-05-20 10:06:07.562429084 +0200
 @@ -13,7 +13,7 @@
  # cmake --build . --config Release
  # cmake --install .
@@ -9,15 +9,6 @@
  project(texmaker VERSION 6.0.1 LANGUAGES CXX C)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
  
-@@ -27,7 +27,7 @@
-     if (${COMPILEUSB} STREQUAL "yes")
-         set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/deploy/linux_portable)
-     else()
--        set(INSTALL_DIR "/usr")
-+        set(INSTALL_DIR "/app")
-     endif()
- elseif (WIN32)
-     if (${COMPILEUSB} STREQUAL "yes")
 @@ -387,6 +387,7 @@
  set(CMAKE_AUTORCC ON)
  
@@ -26,3 +17,18 @@
  
  qt_standard_project_setup()
  
+@@ -1340,12 +1341,11 @@
+         USB_VERSION
+     )
+ endif()
+-set(PREFIX ${INSTALL_DIR})
+ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+-  set(CMAKE_INSTALL_PREFIX ${PREFIX} CACHE PATH "..." FORCE)
++  set(CMAKE_INSTALL_PREFIX ${INSTALL_DIR} CACHE PATH "..." FORCE)
+ endif()
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+-    PREFIX=\"${PREFIX}\"
++    PREFIX=\"${CMAKE_INSTALL_PREFIX}\"
+     )
+ if (${AUTHORIZELINUXQSTYLES} STREQUAL "yes")
+ target_compile_definitions(${PROJECT_NAME} PRIVATE

--- a/CMakeLists.txt.patch
+++ b/CMakeLists.txt.patch
@@ -1,5 +1,5 @@
 --- a/CMakeLists.txt	2026-01-17 16:23:42.056121262 -0500
-+++ b/CMakeLists.txt	2026-01-17 16:26:39.468127580 -0500
++++ b/CMakeLists.txt	2026-05-19 14:17:07.001803545 +0200
 @@ -13,7 +13,7 @@
  # cmake --build . --config Release
  # cmake --install .
@@ -9,6 +9,15 @@
  project(texmaker VERSION 6.0.1 LANGUAGES CXX C)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
  
+@@ -27,7 +27,7 @@
+     if (${COMPILEUSB} STREQUAL "yes")
+         set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/deploy/linux_portable)
+     else()
+-        set(INSTALL_DIR "/usr")
++        set(INSTALL_DIR "/app")
+     endif()
+ elseif (WIN32)
+     if (${COMPILEUSB} STREQUAL "yes")
 @@ -387,6 +387,7 @@
  set(CMAKE_AUTORCC ON)
  


### PR DESCRIPTION
Hello,

Several directories in the app (translations `transdir`, spellchecking `dicDir`, user manual `docfile`...) are computed at the compilation time based on `PREFIX`, that is set to `INSTALL_DIR` in the CMake files. That latter variable is hardcoded to `/usr` by default on Unix systems.

I suggest to change the harcoded path to `/app`. This allows to select a localization in the *Options->Interface Language* menu and automatically load the app using the user locale, load the associated spellchecking dictionary by default as well as the user manual in the *Help->User Manual* menu.

